### PR TITLE
Update version to 1.1.21 to avoid upgrade issues

### DIFF
--- a/System.Net.Mail.Abstractions/System.Net.Mail.Abstractions.csproj
+++ b/System.Net.Mail.Abstractions/System.Net.Mail.Abstractions.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/gavynriebau/System.Net.Mail.Abstractions</RepositoryUrl>
 
     <PackageTags>SmtpClient,TDD,mock,mail</PackageTags>
-    <Version>1.1.2</Version>
+    <Version>1.1.21</Version>
   </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
When the package was migrated from .NET Framework 4.5 to .NET Standard
2.0, the package name was kept but the version number was reset.  This
results in tooling thinking that users of the .NET Core 1.1.2 version
should "upgrade" to 1.1.20.

Updating the version to 1.1.21 to get past the old version numbers.